### PR TITLE
Make te_num_* have consistent datatypes between trec_eval.c and other files

### DIFF
--- a/trec_eval.c
+++ b/trec_eval.c
@@ -122,15 +122,15 @@ static char *usage = "Usage: trec_eval [-h] [-q] {-m measure}* trec_rel_file tre
    -m: calculate and print measures indicated by 'measure'\n\
        ('-m all_qrels' prints all qrels measures, '-m official' is default)\n";
 
-extern long te_num_trec_measures;
+extern int te_num_trec_measures;
 extern TREC_MEAS *te_trec_measures[];
-extern long te_num_trec_measure_nicknames;
+extern int te_num_trec_measure_nicknames;
 extern TREC_MEASURE_NICKNAMES te_trec_measure_nicknames[];
-extern long te_num_rel_info_format;
+extern int te_num_rel_info_format;
 extern REL_INFO_FILE_FORMAT te_rel_info_format[];
-extern long te_num_results_format;
+extern int te_num_results_format;
 extern RESULTS_FILE_FORMAT te_results_format[];
-extern long te_num_form_inter_procs;
+extern int te_num_form_inter_procs;
 extern RESULTS_FILE_FORMAT te_form_inter_procs[];
 
 static int mark_measure (EPI *epi, char *optarg);


### PR DESCRIPTION
This prevents a segfault on my machine: The problem is that 'long' are bigger than ints and the extra memory may not be zero.

My system (more information available upon request):
gcc version 6.3.0 20170415 (Debian 6.3.0-14) 
Description:	Debian GNU/Linux 9.0 (stretch)
Linux kagh-local 4.9.0-2-amd64 #1 SMP Debian 4.9.18-1 (2017-03-30) x86_64 GNU/Linux

Steps to reproduce segfault:
gdb ./trec_eval/trec_eval
(gdb) run -q -m official adhoc-news/assessments/assessments2004/qrels_EN results201
Starting program: /home/frankier/edutmp/ir/lab2/trec_eval/trec_eval -q -m official adhoc-news/assessments/assessments2004/qrels_EN results201

Program received signal SIGSEGV, Segmentation fault.
0x0000555555559520 in main (argc=6, argv=0x7fffffffe1a8) at trec_eval.c:339
339		if (MEASURE_MARKED(te_trec_measures[m])) {

(the files are from a University assignment and can be provided on request)