### PR TITLE
Update sysfunc.h

### DIFF
--- a/sysfunc.h
+++ b/sysfunc.h
@@ -33,8 +33,6 @@
 #endif
 
 /* For time being, define Berkeley constructs in terms of SVR4 constructs*/
-#define bzero(dest,len)      memset(dest,'\0',len)
-#define bcopy(source,dest,len)   memcpy(dest,source,len)
 #define srandom(seed)        srand(seed)
 #define random()             rand()
 


### PR DESCRIPTION
These two defines are never used and they generate a warning:
```
./sysfunc.h:36:9: warning: 'bcopy' macro redefined [-Wmacro-redefined]
#define bcopy(source,dest,len)   memcpy(dest,source,len)
        ^
/usr/include/secure/_strings.h:45:9: note: previous definition is here
#define bcopy(src, dest, ...) \
        ^
1 warning generated.
```