### PR TITLE
Adaptation from Pull Request #17, fence these #defines in #ifndefs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BIN = /usr/local/bin
 
 H   = .
 
-VERSIONID = 9.0.4
+VERSIONID = 9.0.5
 
 # gcc
 CC       = gcc

--- a/sysfunc.h
+++ b/sysfunc.h
@@ -33,8 +33,12 @@
 #endif
 
 /* For time being, define Berkeley constructs in terms of SVR4 constructs*/
+#ifndef bzero
 #define bzero(dest,len)      memset(dest,'\0',len)
+#endif
+#ifndef bcopy
 #define bcopy(source,dest,len)   memcpy(dest,source,len)
+#endif
 #define srandom(seed)        srand(seed)
 #define random()             rand()
 


### PR DESCRIPTION
This is in response to pull request #17 which just removed the #defines for bcopy and bzero.  That fixes a compile warning on macOS.

On Linux (Ubuntu 18) there was no compile warning, so I'm wary of just dropping them.  I decided to fence them in #ifndef's instead.  Tested with quick and longtest on
 * macOS, clang 11.0.0 as gcc
 * Ubuntu 18.04.3 LTS, gcc 7.4.0