### PR TITLE
allow results file to be read from stdin

### DIFF
--- a/get_trec_results.c
+++ b/get_trec_results.c
@@ -72,7 +72,7 @@ te_get_trec_results(EPI * epi, char *text_results_file,
     TEXT_RESULTS *text_results_ptr;
 
     /* mmap entire file into memory and copy it into writable memory */
-    if (text_results_file[0] != '-'){
+    if (text_results_file[0] != '-') {
         if (-1 == (fd = open(text_results_file, 0)) ||
             0 >= (size = lseek(fd, 0L, 2)) ||
             (char *) -1 == (orig_buf = (char *) mmap(0,
@@ -97,13 +97,13 @@ te_get_trec_results(EPI * epi, char *text_results_file,
                     text_results_file);
             return (UNDEF);
         }
-    }else{
+    } else {
         size_t capacity = 4096;
         size = 0; 
         trec_results_buf = malloc(capacity * sizeof (char));
         char lineBuffer[MAXLINE];
-        while (fgets(lineBuffer,MAXLINE,stdin) != NULL){
-            for (int i = 0 ; i < strlen(lineBuffer) ; i++){
+        while (fgets(lineBuffer,MAXLINE,stdin) != NULL) {
+            for (int i = 0; i < strlen(lineBuffer); i++) {
                 trec_results_buf[size] = lineBuffer[i];
                 if (++size == capacity) {
                     long newcap = (capacity *= 2) * sizeof (char);

--- a/get_trec_results.c
+++ b/get_trec_results.c
@@ -12,6 +12,7 @@
 #include <ctype.h>
 #include <sys/types.h>
 
+#define MAXLINE 10000
 /* Read all retrieved results information from trec_results_file.
 Read text tuples from trec_results_file of the form
      030  Q0  ZF08-175-870  0   4238   prise1
@@ -71,29 +72,47 @@ te_get_trec_results(EPI * epi, char *text_results_file,
     TEXT_RESULTS *text_results_ptr;
 
     /* mmap entire file into memory and copy it into writable memory */
-    if (-1 == (fd = open(text_results_file, 0)) ||
-        0 >= (size = lseek(fd, 0L, 2)) ||
-        (char *) -1 == (orig_buf = (char *) mmap(0,
-                                                 (size_t) size,
-                                                 PROT_READ,
-                                                 MAP_SHARED, fd, (off_t) 0))) {
-        fprintf(stderr,
-                "trec_eval.get_results: Cannot read results file '%s'\n",
-                text_results_file);
-        return (UNDEF);
-    }
-    if (NULL == (trec_results_buf = malloc((size_t) size + 2))) {
-        fprintf(stderr,
-                "trec_eval.get_results: Cannot copy results file '%s'\n",
-                text_results_file);
-        return (UNDEF);
-    }
-    (void) memcpy(trec_results_buf, orig_buf, size);
-    if (-1 == munmap(orig_buf, size) || -1 == close(fd)) {
-        fprintf(stderr,
-                "trec_eval.get_results: Cannot close results file '%s'\n",
-                text_results_file);
-        return (UNDEF);
+    if (text_results_file[0] != '-'){
+        if (-1 == (fd = open(text_results_file, 0)) ||
+            0 >= (size = lseek(fd, 0L, 2)) ||
+            (char *) -1 == (orig_buf = (char *) mmap(0,
+                                                    (size_t) size,
+                                                    PROT_READ,
+                                                    MAP_SHARED, fd, (off_t) 0))) {
+            fprintf(stderr,
+                    "trec_eval.get_results: Cannot read results file '%s'\n",
+                    text_results_file);
+            return (UNDEF);
+        }
+        if (NULL == (trec_results_buf = malloc((size_t) size + 2))) {
+            fprintf(stderr,
+                    "trec_eval.get_results: Cannot copy results file '%s'\n",
+                    text_results_file);
+            return (UNDEF);
+        }
+        (void) memcpy(trec_results_buf, orig_buf, size);
+        if (-1 == munmap(orig_buf, size) || -1 == close(fd)) {
+            fprintf(stderr,
+                    "trec_eval.get_results: Cannot close results file '%s'\n",
+                    text_results_file);
+            return (UNDEF);
+        }
+    }else{
+        size_t capacity = 4096;
+        size = 0; 
+        trec_results_buf = malloc(capacity * sizeof (char));
+        char lineBuffer[MAXLINE];
+        while (fgets(lineBuffer,MAXLINE,stdin) != NULL){
+            for (int i = 0 ; i < strlen(lineBuffer) ; i++){
+                trec_results_buf[size] = lineBuffer[i];
+                if (++size == capacity) {
+                    long newcap = (capacity *= 2) * sizeof (char);
+                    trec_results_buf = realloc(trec_results_buf, newcap);
+                }
+            }
+        }
+        trec_results_buf = realloc(trec_results_buf, (size + 3) * sizeof (char));
+        trec_results_buf[size] = '\0';
     }
 
     /* Append ending newline if not present, Append NULL terminator */

--- a/trec_eval.c
+++ b/trec_eval.c
@@ -12,7 +12,8 @@ static char *help_message =
    rel_info_file  results_file \n\
  \n\
 Calculate and print various evaluation measures, evaluating the results  \n\
-in results_file against the relevance info in rel_info_file. \n\
+in results_file against the relevance info in rel_info_file. If results_file is \n\
+'-', then results_file is read from stdin.\n\
  \n\
 There are a fair number of options, of which only the lower case options are \n\
 normally ever used.   \n\


### PR DESCRIPTION
passing in a filename of "-" causes input to be read from stdin.  