### PR TITLE
Changes made to conform with the requirement in gcc 15 (that comes wi…

### DIFF
--- a/form_prefs_counts.c
+++ b/form_prefs_counts.c
@@ -137,9 +137,9 @@ static int form_prefs_and_ranks(const EPI * epi,
 
 static void init_prefs_array(PREFS_ARRAY * pa);
 static void init_counts_array(COUNTS_ARRAY * ca);
-static int comp_prefs_and_ranks_jg_rel_level();
-static int comp_prefs_and_ranks_docno();
-static int comp_sim_docno(), comp_docno(), comp_results_inc_rank();
+static int comp_prefs_and_ranks_jg_rel_level(const void * ptr1, const void * ptr2);
+static int comp_prefs_and_ranks_docno(const void * ptr1, const void * ptr2);
+static int comp_sim_docno(const void * ptr1, const void * ptr2), comp_docno(const void * ptr1, const void * ptr2), comp_results_inc_rank(const void * ptr1, const void * ptr2);
 static void debug_print_ec(EC * ec), debug_print_prefs_array(PREFS_ARRAY * pa),
 debug_print_counts_array(COUNTS_ARRAY * ca), debug_print_jg(JG * jg),
 debug_print_results_prefs(RESULTS_PREFS * rp);
@@ -970,47 +970,49 @@ static void init_counts_array(COUNTS_ARRAY * ca)
 
 
 static int
-comp_prefs_and_ranks_docno(PREFS_AND_RANKS * ptr1, PREFS_AND_RANKS * ptr2)
+comp_prefs_and_ranks_docno(const void * ptr1, const void * ptr2)
 {
-    return (strcmp(ptr1->docno, ptr2->docno));
+    return (strcmp(((PREFS_AND_RANKS *)ptr1)->docno, ((PREFS_AND_RANKS *) ptr2)->docno));
 }
 
 static int
-comp_prefs_and_ranks_jg_rel_level(PREFS_AND_RANKS * ptr1,
-                                  PREFS_AND_RANKS * ptr2)
+comp_prefs_and_ranks_jg_rel_level(const void * ptr1,
+                                  const void * ptr2)
 {
-    int jg_comp = strcmp(ptr1->jg, ptr2->jg);
+    PREFS_AND_RANKS * p1 = (PREFS_AND_RANKS *) ptr1;
+    PREFS_AND_RANKS * p2 = (PREFS_AND_RANKS *) ptr2;
+    int jg_comp = strcmp(p1->jg, p2->jg);
     if (jg_comp != 0)
         return (jg_comp);
-    jg_comp = strcmp(ptr1->jsg, ptr2->jsg);
+    jg_comp = strcmp(p1->jsg, p2->jsg);
     if (jg_comp != 0)
         return (jg_comp);
-    if (ptr1->rel_level > ptr2->rel_level)
+    if (p1->rel_level > p2->rel_level)
         return (-1);
-    if (ptr1->rel_level < ptr2->rel_level)
+    if (p1->rel_level < p2->rel_level)
         return (1);
-    return (ptr1->rank - ptr2->rank);
+    return (p1->rank - p2->rank);
 }
 
-static int comp_sim_docno(ptr1, ptr2)
-DOCNO_RESULTS *ptr1;
-DOCNO_RESULTS *ptr2;
+static int comp_sim_docno(const void * ptr1, const void * ptr2)
 {
-    if (ptr1->sim > ptr2->sim)
+    DOCNO_RESULTS * p1 = (DOCNO_RESULTS *) ptr1;
+    DOCNO_RESULTS * p2 = (DOCNO_RESULTS *) ptr2;
+    if (p1->sim > p2->sim)
         return (-1);
-    if (ptr1->sim < ptr2->sim)
+    if (p1->sim < p2->sim)
         return (1);
-    return (strcmp(ptr1->docno, ptr2->docno));
+    return (strcmp(p1->docno, p2->docno));
 }
 
-static int comp_docno(DOCNO_RESULTS * ptr1, DOCNO_RESULTS * ptr2)
+static int comp_docno(const void * ptr1, const void * ptr2)
 {
-    return (strcmp(ptr1->docno, ptr2->docno));
+    return (strcmp(((DOCNO_RESULTS *) ptr1)->docno, ((DOCNO_RESULTS *) ptr2)->docno));
 }
 
-static int comp_results_inc_rank(DOCNO_RESULTS * ptr1, DOCNO_RESULTS * ptr2)
+static int comp_results_inc_rank(const void * ptr1, const void * ptr2)
 {
-    return (ptr1->rank - ptr2->rank);
+    return (((DOCNO_RESULTS *) ptr1)->rank - ((DOCNO_RESULTS *) ptr2)->rank);
 }
 
 

--- a/form_res_rels.c
+++ b/form_res_rels.c
@@ -27,7 +27,7 @@
    UNDEF returned if error, 0 if used cache values, 1 if new values.
 */
 
-static int comp_rank_judged(), comp_sim_docno(), comp_docno();
+static int comp_rank_judged(const void * ptr1, const void * ptr2), comp_sim_docno(const void * ptr1, const void * ptr2), comp_docno(const void * ptr1, const void * ptr2);
 
 /* Definitions used for temporary and cached values */
 typedef struct {
@@ -245,40 +245,38 @@ te_form_res_rels(const EPI * epi, const REL_INFO * rel_info,
     return (1);
 }
 
-static int comp_rank_judged(ptr1, ptr2)
-DOCNO_INFO *ptr1;
-DOCNO_INFO *ptr2;
+static int comp_rank_judged(const void * ptr1, const void * ptr2)
 {
-    if (ptr1->rel >= 0 && ptr2->rel >= 0) {
-        if (ptr1->rank < ptr2->rank)
+    DOCNO_INFO *p1 = (DOCNO_INFO *) ptr1;
+    DOCNO_INFO *p2 = (DOCNO_INFO *) ptr2;
+    if (p1->rel >= 0 && p2->rel >= 0) {
+        if (p1->rank < p2->rank)
             return (-1);
-        if (ptr1->rank > ptr2->rank)
+        if (p1->rank > p2->rank)
             return (1);
         return (0);
     }
-    if (ptr1->rel >= 0)
+    if (p1->rel >= 0)
         return (-1);
-    if (ptr2->rel >= 0)
+    if (p2->rel >= 0)
         return (1);
     return (0);
 }
 
-static int comp_sim_docno(ptr1, ptr2)
-DOCNO_INFO *ptr1;
-DOCNO_INFO *ptr2;
+static int comp_sim_docno(const void * ptr1, const void * ptr2)
 {
-    if (ptr1->sim > ptr2->sim)
+    DOCNO_INFO *p1 = (DOCNO_INFO *) ptr1;
+    DOCNO_INFO *p2 = (DOCNO_INFO *) ptr2;
+    if (p1->sim > p2->sim)
         return (-1);
-    if (ptr1->sim < ptr2->sim)
+    if (p1->sim < p2->sim)
         return (1);
-    return (strcmp(ptr2->docno, ptr1->docno));
+    return (strcmp(p2->docno, p1->docno));
 }
 
-static int comp_docno(ptr1, ptr2)
-DOCNO_INFO *ptr1;
-DOCNO_INFO *ptr2;
+static int comp_docno(const void * ptr1, const void * ptr2)
 {
-    return (strcmp(ptr1->docno, ptr2->docno));
+    return (strcmp(((DOCNO_INFO *) ptr1)->docno, ((DOCNO_INFO *) ptr2)->docno));
 }
 
 

--- a/form_res_rels_jg.c
+++ b/form_res_rels_jg.c
@@ -28,7 +28,7 @@
    UNDEF returned if error, 0 if used cache values, 1 if new values.
 */
 
-static int comp_rank_judged(), comp_sim_docno(), comp_docno();
+static int comp_rank_judged(const void * ptr1, const void * ptr2), comp_sim_docno(const void * ptr1, const void * ptr2), comp_docno(const void * ptr1, const void * ptr2);
 
 /* Definitions used for temporary and cached values */
 typedef struct {
@@ -260,40 +260,38 @@ te_form_res_rels_jg(const EPI * epi, const REL_INFO * rel_info,
     return (1);
 }
 
-static int comp_rank_judged(ptr1, ptr2)
-DOCNO_INFO *ptr1;
-DOCNO_INFO *ptr2;
+static int comp_rank_judged(const void * ptr1, const void * ptr2)
 {
-    if (ptr1->rel >= 0 && ptr2->rel >= 0) {
-        if (ptr1->rank < ptr2->rank)
+    DOCNO_INFO *p1 = (DOCNO_INFO *) ptr1;
+    DOCNO_INFO *p2 = (DOCNO_INFO *) ptr2;
+    if (p1->rel >= 0 && p2->rel >= 0) {
+        if (p1->rank < p2->rank)
             return (-1);
-        if (ptr1->rank > ptr2->rank)
+        if (p1->rank > p2->rank)
             return (1);
         return (0);
     }
-    if (ptr1->rel >= 0)
+    if (p1->rel >= 0)
         return (-1);
-    if (ptr2->rel >= 0)
+    if (p2->rel >= 0)
         return (1);
     return (0);
 }
 
-static int comp_sim_docno(ptr1, ptr2)
-DOCNO_INFO *ptr1;
-DOCNO_INFO *ptr2;
+static int comp_sim_docno(const void * ptr1, const void * ptr2)
 {
-    if (ptr1->sim > ptr2->sim)
+    DOCNO_INFO *p1 = (DOCNO_INFO *) ptr1;
+    DOCNO_INFO *p2 = (DOCNO_INFO *) ptr2;
+    if (p1->sim > p2->sim)
         return (-1);
-    if (ptr1->sim < ptr2->sim)
+    if (p1->sim < p2->sim)
         return (1);
-    return (strcmp(ptr2->docno, ptr1->docno));
+    return (strcmp(p2->docno, p1->docno));
 }
 
-static int comp_docno(ptr1, ptr2)
-DOCNO_INFO *ptr1;
-DOCNO_INFO *ptr2;
+static int comp_docno(const void * ptr1, const void * ptr2)
 {
-    return (strcmp(ptr1->docno, ptr2->docno));
+    return (strcmp(((DOCNO_INFO*) ptr1)->docno, ((DOCNO_INFO*) ptr2)->docno));
 }
 
 int te_form_res_rels_jg_cleanup()

--- a/functions.h
+++ b/functions.h
@@ -23,7 +23,7 @@ int te_convert_to_zscore(const ALL_ZSCORES * all_zscores, TREC_EVAL * q_eval);
 /* Functions for dealing with gain values, defined in gain_init.c */
 int setup_gains(const TREC_MEAS * tm, const RES_RELS * res_rels, GAINS * gains);
 double get_gain(const long rel_level, const GAINS * gains);
-int comp_rel_gain();
+int comp_rel_gain(const void * ptr1, const void * ptr2);
 
 /* ------------------- Generic Routines for Measures ------------------------ */
 

--- a/gain_init.c
+++ b/gain_init.c
@@ -87,9 +87,9 @@ int setup_gains(const TREC_MEAS * tm, const RES_RELS * res_rels, GAINS * gains)
     return (1);
 }
 
-int comp_rel_gain(REL_GAIN * ptr1, REL_GAIN * ptr2)
+int comp_rel_gain(const void * ptr1, const void * ptr2)
 {
-    return (ptr1->gain - ptr2->gain);
+    return (((REL_GAIN *) ptr1)->gain - ((REL_GAIN *) ptr2)->gain);
 }
 
 double get_gain(const long rel_level, const GAINS * gains)

--- a/get_prefs.c
+++ b/get_prefs.c
@@ -116,7 +116,7 @@ important future research problem.
 
 static int parse_prefs_line(char **start_ptr, char **qid_ptr, char **jg_ptr,
                             char **jsg_ptr, char **docno_ptr, char **rel_ptr);
-static int comp_lines_qid_docno();
+static int comp_lines_qid_docno(const void * ptr1, const void * ptr2);
 
 
 /* static pools of memory, allocated here and never changed.  
@@ -246,12 +246,14 @@ int te_get_prefs(EPI * epi, char *text_prefs_file, ALL_REL_INFO * all_rel_info)
     return (1);
 }
 
-static int comp_lines_qid_docno(LINES * ptr1, LINES * ptr2)
+static int comp_lines_qid_docno(const void * ptr1, const void * ptr2)
 {
-    int cmp = strcmp(ptr1->qid, ptr2->qid);
+    LINES* l1 = (LINES*) ptr1;
+    LINES* l2 = (LINES*) ptr2;
+    int cmp = strcmp(l1->qid, l2->qid);
     if (cmp)
         return (cmp);
-    return (strcmp(ptr1->docno, ptr2->docno));
+    return (strcmp(l1->docno, l2->docno));
 }
 
 static int

--- a/get_qrels.c
+++ b/get_qrels.c
@@ -62,7 +62,7 @@ typedef struct {
 static int parse_qrels_line(char **start_ptr, char **qid_ptr,
                             char **docno_ptr, char **rel_ptr);
 
-static int comp_lines_qid_docno();
+static int comp_lines_qid_docno(const void * ptr1, const void * ptr2);
 
 
 /* static pools of memory, allocated here and never changed.  
@@ -192,12 +192,14 @@ int te_get_qrels(EPI * epi, char *text_qrels_file, ALL_REL_INFO * all_rel_info)
     return (1);
 }
 
-static int comp_lines_qid_docno(LINES * ptr1, LINES * ptr2)
+static int comp_lines_qid_docno(const void * ptr1, const void * ptr2)
 {
-    int cmp = strcmp(ptr1->qid, ptr2->qid);
+    LINES* p1 = (LINES *) ptr1;
+    LINES* p2 = (LINES *) ptr2;
+    int cmp = strcmp(p1->qid, p2->qid);
     if (cmp)
         return (cmp);
-    return (strcmp(ptr1->docno, ptr2->docno));
+    return (strcmp(p1->docno, p2->docno));
 }
 
 static int

--- a/get_qrels_jg.c
+++ b/get_qrels_jg.c
@@ -69,7 +69,7 @@ typedef struct {
 static int parse_qrels_line(char **start_ptr, char **qid_ptr, char **jg_ptr,
                             char **docno_ptr, char **rel_ptr);
 
-static int comp_lines_qid_jg_docno();
+static int comp_lines_qid_jg_docno(const void * ptr1, const void * ptr2);
 
 
 /* static pools of memory, allocated here and never changed.  
@@ -219,15 +219,17 @@ te_get_qrels_jg(EPI * epi, char *text_qrels_file, ALL_REL_INFO * all_rel_info)
     return (1);
 }
 
-static int comp_lines_qid_jg_docno(LINES * ptr1, LINES * ptr2)
+static int comp_lines_qid_jg_docno(const void * ptr1, const void * ptr2)
 {
-    int cmp = strcmp(ptr1->qid, ptr2->qid);
+    LINES* p1 = (LINES *) ptr1;
+    LINES* p2 = (LINES *) ptr2;
+    int cmp = strcmp(p1->qid, p2->qid);
     if (cmp)
         return (cmp);
-    cmp = strcmp(ptr1->jg, ptr2->jg);
+    cmp = strcmp(p1->jg, p2->jg);
     if (cmp)
         return (cmp);
-    return (strcmp(ptr1->docno, ptr2->docno));
+    return (strcmp(p1->docno, p2->docno));
 }
 
 static int

--- a/get_qrels_prefs.c
+++ b/get_qrels_prefs.c
@@ -88,7 +88,7 @@ static int parse_qrels_prefs_line(char **start_ptr, char **qid_ptr,
                                   char **jg_ptr, char **docno_ptr,
                                   char **rel_ptr);
 
-static int comp_lines_qid_docno();
+static int comp_lines_qid_docno(const void * ptr1, const void * ptr2);
 
 
 /* static pools of memory, allocated here and never changed.  
@@ -218,12 +218,14 @@ te_get_qrels_prefs(EPI * epi, char *text_prefs_file,
     return (1);
 }
 
-static int comp_lines_qid_docno(LINES * ptr1, LINES * ptr2)
+static int comp_lines_qid_docno(const void * ptr1, const void * ptr2)
 {
-    int cmp = strcmp(ptr1->qid, ptr2->qid);
+    LINES * p1 = (LINES*) ptr1;
+    LINES * p2 = (LINES*) ptr2;
+    int cmp = strcmp(p1->qid, p2->qid);
     if (cmp)
         return (cmp);
-    return (strcmp(ptr1->docno, ptr2->docno));
+    return (strcmp(p1->docno, p2->docno));
 }
 
 static int

--- a/get_trec_results.c
+++ b/get_trec_results.c
@@ -40,7 +40,7 @@ static int parse_results_line(char **start_ptr, char **qid_ptr,
                               char **docno_ptr, char **sim_ptr,
                               char **run_id_ptr);
 
-static int comp_lines_qid_docno();
+static int comp_lines_qid_docno(const void * ptr1, const void * ptr2);
 
 
 /* static pools of memory, allocated here and never changed.  
@@ -197,12 +197,14 @@ te_get_trec_results(EPI * epi, char *text_results_file,
     return (1);
 }
 
-static int comp_lines_qid_docno(LINES * ptr1, LINES * ptr2)
+static int comp_lines_qid_docno(const void * ptr1, const void * ptr2)
 {
-    int cmp = strcmp(ptr1->qid, ptr2->qid);
+    LINES* p1 = (LINES *) ptr1;
+    LINES* p2 = (LINES *) ptr2;
+    int cmp = strcmp(p1->qid, p2->qid);
     if (cmp)
         return (cmp);
-    return (strcmp(ptr1->docno, ptr2->docno));
+    return (strcmp(p1->docno, p2->docno));
 }
 
 static int

--- a/get_zscores.c
+++ b/get_zscores.c
@@ -55,7 +55,7 @@ typedef struct {
 static int parse_zscore_line(char **start_ptr, char **qid_ptr, char **meas_ptr,
                              char **mean_ptr, char **stddev_ptr);
 
-static int comp_lines_qid_meas();
+static int comp_lines_qid_meas(const void * ptr1, const void * ptr2);
 
 
 /* static pools of memory, allocated here and never changed.  */
@@ -169,12 +169,14 @@ te_get_zscores(const EPI * epi, const char *zscores_file,
     return (1);
 }
 
-static int comp_lines_qid_meas(LINES * ptr1, LINES * ptr2)
+static int comp_lines_qid_meas(const void * ptr1, const void * ptr2)
 {
-    int cmp = strcmp(ptr1->qid, ptr2->qid);
+    LINES *p1 = (LINES*) ptr1;
+    LINES *p2 = (LINES*) ptr2;
+    int cmp = strcmp(p1->qid, p2->qid);
     if (cmp)
         return (cmp);
-    return (strcmp(ptr1->meas, ptr2->meas));
+    return (strcmp(p1->meas, p2->meas));
 }
 
 static int

--- a/meas_init.c
+++ b/meas_init.c
@@ -28,8 +28,8 @@ static int get_long_cutoffs(PARAMS * params, char *param_string);
 static int get_double_cutoffs(PARAMS * params, char *param_string);
 static int get_double_params(PARAMS * params, char *param_string);
 static int get_param_pairs(PARAMS * params, char *param_string);
-static int comp_long();
-static int comp_double();
+static int comp_long(const void * ptr1, const void * ptr2);
+static int comp_double(const void * ptr1, const void * ptr2);
 static char *append_long(char *name, long value);
 static char *append_double(char *name, double value);
 static char *append_string(char *name, char *value);
@@ -454,16 +454,16 @@ static int get_param_pairs(PARAMS * params, char *param_string)
     return (1);
 }
 
-static int comp_long(long *ptr1, long *ptr2)
+static int comp_long(const void *ptr1, const void *ptr2)
 {
-    return (*ptr1 - *ptr2);
+    return (*((long *) ptr1) - *((long *) ptr2));
 }
 
-static int comp_double(double *ptr1, double *ptr2)
+static int comp_double(const void *ptr1, const void *ptr2)
 {
-    if (*ptr1 < *ptr2)
+    if (*((double *) ptr1) < *((double *) ptr2))
         return (-1);
-    if (*ptr1 > *ptr2)
+    if (*((double *) ptr1) > *((double *) ptr2))
         return (1);
     return (0);
 }

--- a/trec_eval.c
+++ b/trec_eval.c
@@ -140,9 +140,7 @@ static void get_debug_level_query(EPI * epi, char *optarg);
 static int cleanup(EPI * epi);
 
 
-int main(argc, argv)
-int argc;
-char *argv[];
+int main(int argc, char * argv[])
 {
     char *trec_results_file;
     ALL_RESULTS all_results;


### PR DESCRIPTION
…th FC43) that

the comparisons functions must be of type comp(const void * ptr1, const void * ptr2).

Please check if you like the way I handled this change, will not be offended if you think the style of the comparison functions should be more or less verbose.

Have run a test with some known result files, but nothing extensively.